### PR TITLE
Allow using mcp-remote to point to localhost mcp servers

### DIFF
--- a/.vendor/mcp-remote/src/shared.ts
+++ b/.vendor/mcp-remote/src/shared.ts
@@ -419,7 +419,10 @@ export async function parseCommandLineArgs(args: string[], defaultPort: number, 
   const serverUrl = args[0]
   const specifiedPort = args[1] ? parseInt(args[1]) : undefined
 
-  if (!serverUrl || !(serverUrl.startsWith('https://') || serverUrl.startsWith('http://localhost'))) {
+  const url = new URL(serverUrl)
+  const isLocalhost = url.hostname === 'localhost' && url.protocol === 'http:'
+
+  if (!serverUrl || !(url.protocol == 'https:' || isLocalhost)) {
     console.error(usage)
     process.exit(1)
   }

--- a/.vendor/mcp-remote/src/shared.ts
+++ b/.vendor/mcp-remote/src/shared.ts
@@ -419,7 +419,7 @@ export async function parseCommandLineArgs(args: string[], defaultPort: number, 
   const serverUrl = args[0]
   const specifiedPort = args[1] ? parseInt(args[1]) : undefined
 
-  if (!serverUrl || !serverUrl.startsWith('https://')) {
+  if (!serverUrl || !(serverUrl.startsWith('https://') || serverUrl.startsWith('http://localhost'))) {
     console.error(usage)
     process.exit(1)
   }

--- a/.vendor/mcp-remote/src/shared.ts
+++ b/.vendor/mcp-remote/src/shared.ts
@@ -419,10 +419,15 @@ export async function parseCommandLineArgs(args: string[], defaultPort: number, 
   const serverUrl = args[0]
   const specifiedPort = args[1] ? parseInt(args[1]) : undefined
 
+  if (!serverUrl) {
+    console.error(usage)
+    process.exit(1)
+  }
+
   const url = new URL(serverUrl)
   const isLocalhost = url.hostname === 'localhost' && url.protocol === 'http:'
 
-  if (!serverUrl || !(url.protocol == 'https:' || isLocalhost)) {
+  if (!(url.protocol == 'https:' || isLocalhost)) {
     console.error(usage)
     process.exit(1)
   }


### PR DESCRIPTION
I tried using this with a local MCP server like you might want to do during development, but was blocked by this. Extended the check to allow `http` IFF we're talking to localhost